### PR TITLE
Change np.zeros() init to int16 type

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM continuumio/miniconda3:4.8.2
 
 RUN apt-get update && apt-get install -y procps && apt-get install -y nano && apt-get -y install gcc && apt-get -y install unzip && apt-get -y install curl && apt-get -y install wget
 
-RUN pip install git+https://github.com/kmayerb/tcrdist3.git@0.1.4
+RUN pip install git+https://github.com/kmayerb/tcrdist3.git@0.1.5
 
 RUN pip install python-levenshtein==0.12.0
 RUN pip install pytest

--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ tcrdist3 is a python API-enabled toolkit for analyzing T-cell receptor repertoir
 ## Installation
 
 ```
-pip install git+https://github.com/kmayerb/tcrdist3.git@0.1.4
+pip install git+https://github.com/kmayerb/tcrdist3.git@0.1.5
 ```
 
 ## Docker
 [![Docker Repository on Quay](https://quay.io/repository/kmayerb/tcrdist3/status "Docker Repository on Quay")](https://quay.io/repository/kmayerb/tcrdist3)
 
 ```
-docker pull quay.io/kmayerb/tcrdist3:0.1.4
+docker pull quay.io/kmayerb/tcrdist3:0.1.5
 ```
 
 ## Documentation

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,7 +17,7 @@ Installation
 
 .. code-block:: none
 
-   pip install git+https://github.com/kmayerb/tcrdist3.git@0.1.4
+   pip install git+https://github.com/kmayerb/tcrdist3.git@0.1.5
 
 
 Docker Container
@@ -25,7 +25,7 @@ Docker Container
 
 .. code-block:: none
 
-   docker pull quay.io/kmayerb/tcrdist3:0.1.4
+   docker pull quay.io/kmayerb/tcrdist3:0.1.5
 
 If you need more details, checkout out the page on the tcrdist3 :ref:`docker` container.
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ opts = dict(name='tcrdist3',
             license='MIT',
             author='Koshlan Mayer-Blackwell',
             author_email='kmayerbl@fredhutch.org',
-            version='0.1.4',
+            version='0.1.5',
             packages=PACKAGES,
             package_data={"": ["*.csv","*.tsv","*.txt"]},
            )

--- a/tcrdist/rep_funcs.py
+++ b/tcrdist/rep_funcs.py
@@ -97,7 +97,7 @@ def _pws(df, metrics, weights, kargs, df2 = None, cpu = 1, uniquify = True, stor
         if store:
            s[k] = pw_mat 
         if tcrdist is None:
-            tcrdist = np.zeros(pw_mat.shape)
+            tcrdist = np.zeros(pw_mat.shape).astype('int16')
         tcrdist = tcrdist + (weights[k] * pw_mat)
     
     s['tcrdist'] = tcrdist

--- a/tcrdist/rep_funcs.py
+++ b/tcrdist/rep_funcs.py
@@ -97,7 +97,7 @@ def _pws(df, metrics, weights, kargs, df2 = None, cpu = 1, uniquify = True, stor
         if store:
            s[k] = pw_mat 
         if tcrdist is None:
-            tcrdist = np.zeros(pw_mat.shape).astype('int16')
+            tcrdist = np.zeros(pw_mat.shape, dtype=np.int16)
         tcrdist = tcrdist + (weights[k] * pw_mat)
     
     s['tcrdist'] = tcrdist


### PR DESCRIPTION
Given that pwseqdist is returning integer distances, we may be able to save considerable memory by initializing the tcrdistance as zero integers instead of zero floats.