### PR TITLE
Update df to df_pop

### DIFF
--- a/tcrdist/rep_diff.py
+++ b/tcrdist/rep_diff.py
@@ -71,7 +71,7 @@ def neighborhood_diff(clone_df, pwmat, x_cols, count_col='count', knn_neighbors=
     -------
     res : pd.DataFrame [nclones x results]
         Results from testing the neighborhood around each clone."""
-    res = hd.neighborhood_tally(df=clone_df,
+    res = hd.neighborhood_tally(df_pop=clone_df,
                                   pwmat=pwmat,
                                   x_cols=x_cols,
                                   count_col=count_col,


### PR DESCRIPTION
The newest version of hierdiff.neighborhood_tally changed argument names from df to df_pop. 

In this patch, rep_diff neighborhood_diff call to `hd.neighborhood_tally`  function changed to reflect this!