### PR TITLE
Updating ECDFs and fixing warnings

### DIFF
--- a/tcrdist/background.py
+++ b/tcrdist/background.py
@@ -263,9 +263,9 @@ def get_stratified_gene_usage_frequency(ts = None, replace = True):
     ts.j_occur_freq_stratified = { x[0]:x[1] for x in df_j_occur_freq.to_dict('split')['data']}
     
     if replace:
-        warnings.warn("REPLACING ts.vj_occur_freq WITH ts.vj_occur_freq_stratified")
-        warnings.warn("REPLACING ts.v_occur_freq  WITH ts.v_occur_freq_stratified")
-        warnings.warn("REPLACING ts.j_occur_freq  WITH ts.j_occur_freq_stratified")
+        warnings.warn("REPLACING ts.vj_occur_freq WITH ts.vj_occur_freq_stratified", stacklevel=2)
+        warnings.warn("REPLACING ts.v_occur_freq  WITH ts.v_occur_freq_stratified", stacklevel=2)
+        warnings.warn("REPLACING ts.j_occur_freq  WITH ts.j_occur_freq_stratified", stacklevel=2)
         ts.vj_occur_freq = ts.vj_occur_freq_stratified 
         ts.v_occur_freq  = ts.v_occur_freq_stratified 
         ts.j_occur_freq  = ts.j_occur_freq_stratified 

--- a/tcrdist/diversity.py
+++ b/tcrdist/diversity.py
@@ -252,13 +252,13 @@ def fuzzy_diversity(counts, pwmat, order=2, threshold=1, nsamples=1000, force_sa
         """The pwmat represents drawing two members and seeing if they are similar
         so order = 2 is just a simple summary of the pairwise distance matrix:
         the proportion of distance pairs that represent similar members"""
-        div = np.sum(cts[up] * (pwmat < threshold)[up]) / np.sum(cts)
+        div = np.sum(cts[up] * (pwmat <= threshold)[up]) / np.sum(cts)
     else:
         """Higher orders could be computed using a sampling approach
         since its not scalable to compute all possible triplets, etc.
         to see which are all similar. A triplet consists of 3 pairwise distances
         that must all be within the threshold to be a similar triplet."""
-        dvec = (pwmat < threshold)[up]
+        dvec = (pwmat <= threshold)[up]
         prob = cts[up] / np.sum(cts[up])
         samples = np.random.choice(dvec, size=(order, nsamples), replace=True, p=prob)
         

--- a/tcrdist/ecdf.py
+++ b/tcrdist/ecdf.py
@@ -28,9 +28,8 @@ def distance_ecdf(pwrect, thresholds=None, weights=None):
 
     Returns
     -------
-    ecdf : vector, thresholds.shape[0]
     thresholds : vector, thresholds.shape[0]
-    """
+    ecdf : vector, thresholds.shape[0]"""
     if weights is None:
         weights = np.ones(pwrect.shape[1])
 
@@ -41,8 +40,7 @@ def distance_ecdf(pwrect, thresholds=None, weights=None):
     ecdf = np.sum((pwrect[:, :, None] <= thresholds[None, None, :]) * \
             weights[None, :, None], axis=1) / np.sum(weights)
     
-    return ecdf
-
+    return thresholds, ecdf
 
 def make_ecdf_step(thresholds, ecdf, add00=False):
     """Create stepped vector for plotting an ECDF,

--- a/tcrdist/ecdf.py
+++ b/tcrdist/ecdf.py
@@ -32,9 +32,15 @@ def distance_ecdf(pwrect, thresholds=None, weights=None):
     ecdf : vector, thresholds.shape[0]"""
     if weights is None:
         weights = np.ones(pwrect.shape[1])
+    else:
+        weights = np.asarray(weights)
 
     if thresholds is None:
         thresholds = np.unique(pwrect[:])
+    else:
+        thresholds = np.asarray(thresholds)
+
+    pwrect = np.asarray(pwrect)
 
     """Vectorized and faster, using broadcasting for the <= expression"""
     """ecdf = np.sum((pwrect[:, :, None] <= thresholds[None, None, :]) * \

--- a/tcrdist/ecdf.py
+++ b/tcrdist/ecdf.py
@@ -1,0 +1,85 @@
+import numpy as np
+import pandas as pd
+
+__all__ = ['distance_ecdf',
+           'make_ecdf_step']
+
+def distance_ecdf(pwrect, thresholds=None, weights=None):
+    """Computes the empirical cumulative distribution function (ECDF) for
+    each TCR in a set of target TCRs [rows of pwrect] as the proportion
+    of reference TCRs [columns of pwrect] within a distance radius less
+    than or equal to a threhold d_i, over a range of
+    D = [d_1, d_2, ..., d_i]. The distances between pairs of TCRs in the
+    target and reference set are contained in the elements of pwrect.
+
+    Optionally, relative weights can be supplied for each reference TCR.
+    These can be TCR counts or other weights andthe ECDF will still
+    be a probability on [0, 1].
+
+    Parameters
+    ----------
+    clone_df : pd.DataFrame
+    pwrect : np.ndarray or scipy.sparse.csr_matrix, (clone_df.shape[0], n_ref)
+    thresholds : np.ndarray
+        Vector of thresholds at which the ECDF should be evaluated.
+        By default will use all unique values in pwrect.
+    weights : np.ndarray or list, (clone_df.shape[0], )
+        Relative weight of each TCR in the reference (column dimension of pwrect)
+
+    Returns
+    -------
+    ecdf : vector, thresholds.shape[0]
+    thresholds : vector, thresholds.shape[0]
+    """
+    if weights is None:
+        weights = np.ones(pwrect.shape[1])
+
+    if thresholds is None:
+        thresholds = np.unique(pwrect[:])
+
+    """Vectorized and faster, using broadcasting for the <= expression"""
+    ecdf = np.sum((pwrect[:, :, None] <= thresholds[None, None, :]) * \
+            weights[None, :, None], axis=1) / np.sum(weights)
+    
+    return ecdf
+
+
+def make_ecdf_step(thresholds, ecdf, add00=False):
+    """Create stepped vector for plotting an ECDF,
+    since the ECDF should naturally have discrete steps
+    but will not unless they are explictly added prior
+    to plotting.
+
+    Takes outputs from distance_ecdf function, but
+    is general for creating stepped vectors for plotting.
+
+    Parameters
+    ----------
+    thresholds : np.ndarray [n_thresholds, ]
+        Vector of thresholds
+        (typically the x-axis of the plot)
+    ecdf : np.ndarray [n_thresholds, ]
+        Vector of increasing probabilities
+        (typically the y-axis of the plot)
+    add00 : bool
+        Will add a step to (x=0, y=0) to complete
+        the ECDF.
+
+    Returns
+    -------
+    x, y : np.ndarray
+        Vectors for plotting"""
+    y = np.asarray(ecdf)
+    t = np.asarray(thresholds)
+    if add00:
+        t = np.concatenate(([0], t.ravel()))
+        y = np.concatenate(([0], y.ravel()))
+
+    t = np.concatenate(([t[0]], np.repeat(t[1:].ravel(), 2)))
+    y = np.repeat(y.ravel(), 2)[:-1]
+    return t, y
+
+def gmean10(vec, axis=0):
+    """Geometric mean which may be useful for
+    summarizing many ECDF functions"""
+    return 10 ** (np.mean(np.log10(vec), axis=axis))

--- a/tcrdist/ecdf.py
+++ b/tcrdist/ecdf.py
@@ -37,8 +37,15 @@ def distance_ecdf(pwrect, thresholds=None, weights=None):
         thresholds = np.unique(pwrect[:])
 
     """Vectorized and faster, using broadcasting for the <= expression"""
-    ecdf = np.sum((pwrect[:, :, None] <= thresholds[None, None, :]) * \
-            weights[None, :, None], axis=1) / np.sum(weights)
+    """ecdf = np.sum((pwrect[:, :, None] <= thresholds[None, None, :]) * \
+            weights[None, :, None], axis=1) / np.sum(weights)"""
+    
+    """Decided not to vectorize in 3D because it can create an array that's
+    too big for memory"""
+    ecdf = np.zeros((pwrect.shape[0], thresholds.shape[0]))
+    for i in range(pwrect.shape[0]):
+        ecdf[i, :] = np.sum((pwrect[i, :][:, None] <= thresholds[None, :]) * \
+                        weights[:, None], axis=0) / np.sum(weights)
     
     return thresholds, ecdf
 

--- a/tcrdist/mappers.py
+++ b/tcrdist/mappers.py
@@ -519,7 +519,7 @@ def map_genes_to_first_alleles(genes, organism):
             alleles.append(d[organism][g])
         except KeyError:
             alleles.append(None)
-            warnings.warn("{} not found in mapping DB, no allele could be mapped for this gene".format(g))
+            warnings.warn("{} not found in mapping DB, no allele could be mapped for this gene".format(g), stacklevel=2)
     return(alleles)
 
 def populate_legacy_fields(df, chains =['alpha', 'beta']):

--- a/tcrdist/pgen.py
+++ b/tcrdist/pgen.py
@@ -177,7 +177,7 @@ class OlgaModel:
                # print(f"pgen_model.V_mask_mapping: {self.pgen_model.V_mask_mapping[gene_to_num_str(V, 'V')]}")
                 vnum = random.choice(self.pgen_model.V_mask_mapping[gene_to_num_str(V, "V")])
             except KeyError:
-                warnings.warn(f"{V}:{gene_to_num_str(V, 'V')} not supported in Olga pgen_model, returning None")
+                warnings.warn(f"{V}:{gene_to_num_str(V, 'V')} not supported in Olga pgen_model, returning None", stacklevel=2)
                 return None
         else:
             vnum = None  
@@ -191,7 +191,7 @@ class OlgaModel:
                 #print(f"pgen_model.J_mask_mapping: {self.pgen_model.J_mask_mapping[gene_to_num_str(J, 'J')]}")
                 jnum = random.choice(self.pgen_model.J_mask_mapping[gene_to_num_str(J, "J")])
             except KeyError:
-                warnings.warn(f"{J}:{gene_to_num_str(J, 'J')} not supported in Olga pgen_model, returning None")
+                warnings.warn(f"{J}:{gene_to_num_str(J, 'J')} not supported in Olga pgen_model, returning None", stacklevel=2)
                 return None
         else:
             jnum = None       

--- a/tcrdist/repertoire.py
+++ b/tcrdist/repertoire.py
@@ -495,7 +495,10 @@ class TCRrep:
         if np.sum(self.cell_df['count']) != np.sum(clone_df['count']):
             n_cells_lost = np.sum(self.cell_df['count']) - np.sum(clone_df['count'])
             n_cell = np.sum(self.cell_df['count'])
-            warnings.warn(f"Not all cells/sequences could be grouped into clones. {n_cells_lost} of {n_cell} were not captured. This occurs when any of the values in the index columns are null or missing for a given sequence. To see entries with missing values use: tcrdist.repertoire.TCRrep._show_incomplete()\n")
+            warnings.warn(f"Not all cells/sequences could be grouped into clones."
+                          f"{n_cells_lost} of {n_cell} were not captured. This occurs when "
+                          "any of the values in the index columns are null or missing for a given sequence. "
+                          "To see entries with missing values use: tcrdist.repertoire.TCRrep._show_incomplete()", stacklevel=2)
         
         # if no clone id column provided thetrn create one as a sequence of numbers
         if "clone_id" not in clone_df:
@@ -654,7 +657,7 @@ class TCRrep:
             aa_string = self.all_genes[organism][gene].__dict__[attr][cdr]
         except KeyError:
             aa_string = None
-            warnings.warn("{} gene was not recognized in reference db no cdr seq could be inferred".format(gene))
+            warnings.warn("{} gene was not recognized in reference db no cdr seq could be inferred".format(gene), stacklevel=2)
         return(aa_string)
        
         """
@@ -666,7 +669,7 @@ class TCRrep:
         Issues warning if invalid organism is passed to TCRrep __init__
         """
         if self.db_file not in ['alphabeta_gammadelta_db.tsv','alphabeta_db.tsv','gammadelta_db.tsv']:
-            warnings.warn("db_file must be 'alphabeta_gammadelta_db.tsv' or 'alphabeta_db.tsv' or 'gammadelta_db.tsv' unless you have built tcrdist3 from scratch")
+            warnings.warn("db_file must be 'alphabeta_gammadelta_db.tsv' or 'alphabeta_db.tsv' or 'gammadelta_db.tsv' unless you have built tcrdist3 from scratch", stacklevel=2)
     
     def _validate_organism(self):
         """
@@ -692,35 +695,35 @@ class TCRrep:
         Issues warning if TCRrep.cell_df not properly formatted.
         """
         if not isinstance(self.cell_df, pd.DataFrame):
-            warnings.warn('TCRrep cell_df argument must be pandas.DataFrame unless you are providing a clone_df directly\n')
+            warnings.warn('TCRrep cell_df argument must be pandas.DataFrame unless you are providing a clone_df directly\n', stacklevel=2)
 
         else:
             cell_df_columns = self.cell_df.columns.to_list()
             
             if "count" not in cell_df_columns:
-                warnings.warn("cell_df needs a counts column to track clonal number of frequency\n")
+                warnings.warn("cell_df needs a counts column to track clonal number of frequency\n", stacklevel=2)
                 warnings.warn("No 'count' column provided; count column set to 1")
                 self.cell_df['count'] = 1
             if "alpha" in self.chains:
                 if not "cdr3_a_aa" in cell_df_columns:
-                    warnings.warn("cell_df needs a column called 'cdr3_a_aa' to track the CDR3 amino acid sequence\n")
+                    warnings.warn("cell_df needs a column called 'cdr3_a_aa' to track the CDR3 amino acid sequence\n", stacklevel=2)
                 if not "v_a_gene" in cell_df_columns:
-                    warnings.warn("cell_df needs a column called 'v_a_gene' for default functions\n")
+                    warnings.warn("cell_df needs a column called 'v_a_gene' for default functions\n", stacklevel=2)
             if "beta" in self.chains:
                 if not "cdr3_b_aa" in cell_df_columns:
-                    warnings.warn("cell_df needs a column called 'cdr3_b_aa' to track the CDR3 amino acid sequence\n")
+                    warnings.warn("cell_df needs a column called 'cdr3_b_aa' to track the CDR3 amino acid sequence\n", stacklevel=2)
                 if not "v_b_gene" in cell_df_columns:
-                    warnings.warn("cell_df needs a column called 'v_b_gene' for default functions\n")
+                    warnings.warn("cell_df needs a column called 'v_b_gene' for default functions\n", stacklevel=2)
             if "gamma" in self.chains:
                 if not "cdr3_g_aa" in cell_df_columns:
-                    warnings.warn("cell_df needs a column called 'cdr3_g_aa' to track the CDR3 amino acid sequence\n")
+                    warnings.warn("cell_df needs a column called 'cdr3_g_aa' to track the CDR3 amino acid sequence\n", stacklevel=2)
                 if not "v_g_gene" in cell_df_columns:
-                    warnings.warn("cell_df needs a column called 'v_g_gene' for default functions\n")
+                    warnings.warn("cell_df needs a column called 'v_g_gene' for default functions\n", stacklevel=2)
             if "delta" in self.chains:
                 if not "cdr3_d_aa" in cell_df_columns:
-                    warnings.warn("cell_df needs a column called 'cdr3_d_aa' to track the CDR3 amino acid sequence\n")
+                    warnings.warn("cell_df needs a column called 'cdr3_d_aa' to track the CDR3 amino acid sequence\n", stacklevel=2)
                 if not "v_d_gene" in cell_df_columns:
-                    warnings.warn("cell_df needs a column called 'v_d_gene' for default functions\n")
+                    warnings.warn("cell_df needs a column called 'v_d_gene' for default functions\n", stacklevel=2)
 
     def _validate_imgt_aligned(self):
         """

--- a/tcrdist/tests/test_ecdf_example.py
+++ b/tcrdist/tests/test_ecdf_example.py
@@ -1,0 +1,66 @@
+import pytest
+
+def test_dash_ecdf():
+    """
+    An empirical distribution function (ECDF) can be created
+    for a target TCR and a reference set of TCRs to show
+    the proportion of reference TCRs that are within a distance
+    D of the target TCR, over a range of distances.
+
+    A plot of the ECDF as a function of increasing D shows the
+    density of TCR space in the reference set in the neighborhood
+    around the target TCR. This can be very helpful for 
+    identifying dense antigen-specific clusters in an antigen
+    enriched TCR repertoire, where the "reference" set is 
+    actually an experimentally enriched repertoire (e.g. 
+    pMHC:tetramer or AIM sorting). Or the ECDF can be helpful
+    for identifying a radius around a TCR that retains high
+    antigen specificity, by showing that the neighborhood
+    is extremely sparse in an large unsorted/bulk TCR repertoire.
+    
+    """
+    import pandas as pd
+    from tcrdist.repertoire import TCRrep
+    from tcrsampler.sampler import TCRsampler
+    from tcrdist.ecdf import distance_ecdf, make_ecdf_step
+
+    df = pd.read_csv('dash.csv')
+    tr = TCRrep(cell_df = df, 
+                organism = 'mouse', 
+                chains = ['beta'], 
+                db_file = 'alphabeta_gammadelta_db.tsv')
+
+    TCRsampler.download_background_file(download_file = 'ruggiero_mouse_sampler.zip')
+    ts = TCRsampler(default_background = 'ruggiero_mouse_beta_t.tsv.sampler.tsv')
+    ts.build_background(stratify_by_subject = True, use_frequency = False)
+    
+    tmp = df[['v_b_gene', 'j_b_gene']].applymap(lambda s: s.split('*')[0] + '*01')
+
+    freqs = tmp.groupby(['v_b_gene', 'j_b_gene']).agg(lambda v: v.shape[0])
+    freqs = list(freqs.to_frame().to_records())
+    ref = ts.sample(freqs, depth=100, seed=110820)
+    ref_df = pd.concat([pd.DataFrame({'cdr3_b_aa':ref[i]}).assign(v_b_gene=v, j_b_gene=j) for i,(v,j,_) in enumerate(freqs)])
+    ref_df.loc[:, 'count'] = 1
+        
+    ref_tr = TCRrep(cell_df=ref_df, 
+                    organism='mouse', 
+                    chains=['beta'],
+                    compute_distances=False,
+                    store_all_cdr=False)
+
+    tr.compute_rect_distances(df=tr.clone_df, df2=ref_tr.clone_df, store=False)
+    
+    """TODO: Add weights to correct for sampling. Also add randomly sampled sequences"""
+    thresholds, ecdf = distance_ecdf(tr.rw_beta, thresholds=None, weights=None)
+
+    figh = plt.figure(figsize=(5, 5))
+    axh = figh.add_axes([0.15, 0.15, 0.6, 0.7], yscale='log')
+    plt.ylabel(f'Proportion of reference TCRs')
+    plt.xlabel(f'Distance from target TCR clone')
+
+    for tari in range(ecdf.shape[0]):
+        x, y = make_ecdf_step(thresholds, ecdf[tari, :])
+        axh.plot(x, y, color=k, alpha=0.2)
+    
+    x, y = make_ecdf_step(thresholds, np.mean(ecdf, axis=0))
+    axh.plot(x, y, color='r', alpha=1)

--- a/tcrdist/tree.py
+++ b/tcrdist/tree.py
@@ -365,7 +365,7 @@ def _auto_hdiff2(tcrrep,
             [['X1','X2'][randint(2)] for x in range(tcrrep.clone_df.shape[0])]
         default_hcluster_diff_kwargs['x_cols'] = ['dummy']
         default_hcluster_diff_kwargs['test_method'] = 'fishers' 
-        warnings.warn(f"Because x_cols was None, setting random dummy values, and using {default_hcluster_diff_kwargs['test_method']}\n")
+        warnings.warn(f"Because x_cols was None, setting random dummy values, and using {default_hcluster_diff_kwargs['test_method']}\n", stacklevel=2)
     
     elif tcrrep.clone_df[x_cols].nunique()[0] == 2: 
         default_hcluster_diff_kwargs['test_method'] = 'fishers' 
@@ -378,7 +378,7 @@ def _auto_hdiff2(tcrrep,
             [['X1','X2'][randint(2)] for x in range(tcrrep.clone_df.shape[0])]
         default_hcluster_diff_kwargs['x_cols'] = ['dummy']
         default_hcluster_diff_kwargs['test_method'] = 'fishers' 
-        warnings.warn(f"Because x_cols was None, setting random dummy values, and using {default_hcluster_diff_kwargs['test_method']}\n")
+        warnings.warn(f"Because x_cols was None, setting random dummy values, and using {default_hcluster_diff_kwargs['test_method']}\n", stacklevel=2)
 
     """ Run hcluster_df """
     


### PR DESCRIPTION
Currently the warnings default to stacklevel=1 which means that the exact line of code that generates the warning is printed directly below the warning text. This means the warning is effectively printed twice.