### PR TITLE
Add PGEN tests for mouse

### DIFF
--- a/tcrdist/background.py
+++ b/tcrdist/background.py
@@ -85,7 +85,7 @@ def calculate_adjustment(df, cols = ['v_b_gene','j_b_gene'], adjcol = 'pVJ'):
     pd.Series
     """
     xdf = df[cols].groupby(cols).size().reset_index()
-    xdf.columns = ['v_b_gene','j_b_gene', 'n']
+    xdf.columns = cols + ['n']
     # For each V,J pairing compute frequency in this reference
     xdf['ref_freq'] = xdf['n'] / xdf['n'].sum()
     df = df.merge(xdf, how = "left", on = cols).reset_index()
@@ -198,7 +198,7 @@ def make_vj_matched_background(
             pass
     
     df = pd.concat(dfs).reset_index(drop = True)
-    df = df[df.cdr3_b_aa.notna()][cols]
+    df = df[df[cols[2]].notna()][cols]
     
     if ts is None:
         from tcrsampler.sampler import TCRsampler
@@ -424,7 +424,7 @@ def _synthesize_human_alpha_vj_background(ts,fn = None, df = None):
     # Subset columns
     df_target = df_target[['v_a_gene','j_a_gene','cdr3_a_aa']]
     # Make a gene usage counter
-    gene_usage_counter = make_gene_usage_counter(df_target)                             # 2
+    gene_usage_counter = make_gene_usage_counter(df_target, cols = ['v_a_gene', 'j_a_gene'])                             # 2
     print("MAKING A V-GENE, J-GENE MATCHED BACKGROUND.")
     # Check that sampler is using sample stratified frequencies. 
     assert ts.v_occur_freq is ts.v_occur_freq_stratified
@@ -441,7 +441,7 @@ def _synthesize_human_alpha_vj_background(ts,fn = None, df = None):
     df_vj_bkgd = df_vj_bkgd.sample(100000, random_state = 1).reset_index(drop = True)
     print("CALCULATE INVERSE PROBABILITY WEIGHT ADJUSTMENT.")
     # Calculate the invese weighting adjustmetn
-    df_vj_bkgd['weights'] = calculate_adjustment(df = df_vj_bkgd, adjcol = "pVJ")
+    df_vj_bkgd['weights'] = calculate_adjustment(df = df_vj_bkgd, adjcol = "pVJ", cols = ['v_a_gene','j_a_gene'])
     df_vj_bkgd['source'] = "vj_matched"
     # Combine
     return df_vj_bkgd
@@ -475,7 +475,7 @@ def _synthesize_mouse_beta_vj_background(ts, fn = None, df = None):
     # Subset columns
     df_target = df_target[['v_b_gene','j_b_gene','cdr3_b_aa']]
     # Make a gene usage counter
-    gene_usage_counter = make_gene_usage_counter(df_target)                             # 2
+    gene_usage_counter = make_gene_usage_counter(df_target, cols = ['v_b_gene', 'j_b_gene'])                             # 2
     print("MAKING A V-GENE, J-GENE MATCHED BACKGROUND.")
     # Check that sampler is using sample stratified frequencies. 
     assert ts.v_occur_freq is ts.v_occur_freq_stratified
@@ -493,6 +493,57 @@ def _synthesize_mouse_beta_vj_background(ts, fn = None, df = None):
     print("CALCULATE INVERSE PROBABILITY WEIGHT ADJUSTMENT.")
     # Calculate the invese weighting adjustmetn
     df_vj_bkgd['weights'] = calculate_adjustment(df = df_vj_bkgd, adjcol = "pVJ")
+    df_vj_bkgd['source'] = "vj_matched"
+    # Combine
+    return df_vj_bkgd
+
+def _synthesize_mouse_alpha_vj_background(ts, fn = None, df = None):
+    """
+    _build_vj_background
+
+    Parameters
+    ----------
+    ts: tcrsampler.TCRsampler() 
+        a TCRsampler instance, with gene usage frequencies (ideally computed get_stratified_gene_usage_frequency()
+    fn: str
+        file path to MIRA set of TCRs
+    df : pandas DataFrame
+        MIRA set of TCRs
+    Returns
+    -------
+    df_vj_bkgd : Pandas DataFrame
+        A set of background TCRs with the same V and J gene usage as the input set. 
+        These are generated using OLGA (Sethna et al.)
+    """
+    if fn is not None and df is not None:
+        raise ValueError("_build_vj_background can accept <df> or <fn> arguments but not both")
+    if fn is not None:
+        # Load a set set of TCRs.
+        df_target = pd.read_csv(fn)
+    if df is not None:
+        df_target = df.copy()
+    # Subset columns
+    df_target = df_target[['v_a_gene','j_a_gene','cdr3_a_aa']]
+    # Make a gene usage counter
+    gene_usage_counter = make_gene_usage_counter(df_target, cols = ['v_a_gene', 'j_a_gene'] )                             # 2
+    print("MAKING A V-GENE, J-GENE MATCHED BACKGROUND.")
+    # Check that sampler is using sample stratified frequencies. 
+    assert ts.v_occur_freq is ts.v_occur_freq_stratified
+    print("USING STRATIFIED FREQUENCIES.")
+    # Make a vj matched background. 
+    #   Note: <size> aregument should be greater than desired, because Olga can return none due to non-productive CDR3s.
+    df_vj_bkgd = make_vj_matched_background(ts = ts,
+        gene_usage_counter = gene_usage_counter,    
+        size = 150000, 
+        recomb_type="VJ", 
+        chain_folder = "mouse_T_alpha",
+        cols = ['v_a_gene', 'j_a_gene', 'cdr3_a_aa'])
+    # Sample to get the desired number of TCRs from teh v,j matched set
+    df_vj_bkgd = df_vj_bkgd.sample(100000, random_state = 1, replace = True).reset_index(drop = True)
+    print("CALCULATE INVERSE PROBABILITY WEIGHT ADJUSTMENT.")
+    print(df_vj_bkgd)
+    # Calculate the invese weighting adjustmetn
+    df_vj_bkgd['weights'] = calculate_adjustment(df = df_vj_bkgd, adjcol = "pVJ", cols = ['v_a_gene','j_a_gene'])
     df_vj_bkgd['source'] = "vj_matched"
     # Combine
     return df_vj_bkgd

--- a/tcrdist/repertoire.py
+++ b/tcrdist/repertoire.py
@@ -6,7 +6,7 @@ from . import repertoire_db
 from tcrdist.rep_funcs import _pws, compute_pws_sparse
 from tcrdist.sample import _default_sampler
 from tcrdist.background import get_stratified_gene_usage_frequency
-from tcrdist.background import _synthesize_human_beta_vj_background, _synthesize_human_alpha_vj_background, _synthesize_mouse_beta_vj_background
+from tcrdist.background import _synthesize_human_beta_vj_background, _synthesize_human_alpha_vj_background, _synthesize_mouse_beta_vj_background, _synthesize_mouse_alpha_vj_background
 from zipdist.zip2 import Zipdist2
 import sys
 
@@ -668,12 +668,15 @@ class TCRrep:
                 vj_background = _synthesize_mouse_beta_vj_background(ts = ts, df = self.clone_df)
         # TODO: ADD OTHER OPTIONS
         elif chain == "alpha":
+            if ts is None:
+                ts = _default_sampler(organism = self.organism, chain = "alpha")()
+                ts = get_stratified_gene_usage_frequency(ts = ts, replace = True) 
             if self.organism == "human":
-                raise ValueError("TODO: FUTURE VERSIONS NEED ALPHA(HUMAN)")
-                #vj_background = _synthesize_human_alpha_vj_background(ts = ts, df = self.clone_df)
+                #raise ValueError("TODO: FUTURE VERSIONS NEED ALPHA(HUMAN)")
+                vj_background = _synthesize_human_alpha_vj_background(ts = ts, df = self.clone_df)
             elif self.organism == "mouse":
-                raise ValueError("TODO: FUTURE VERSIONS NEED ALPHA(MOUSE)")
-                #vj_background = _synthesize_alpha_beta_vj_background(ts = ts, df = self.clone_df)
+                #raise ValueError("TODO: FUTURE VERSIONS NEED ALPHA(MOUSE)")
+                vj_background = _synthesize_mouse_alpha_vj_background(ts = ts, df = self.clone_df)
         return vj_background   
 
 

--- a/tcrdist/tests/test_pgen_mouse.py
+++ b/tcrdist/tests/test_pgen_mouse.py
@@ -1,0 +1,103 @@
+import pytest
+"""
+OLGA (Sethna et al 2019) is a fast tool for estimating the probability of generations
+(i.e. Pgen). In this example we are going to estimate Pgens for the dash.csv data.
+"""
+def test_pgen_mouse():
+	import pandas as pd
+	from tcrdist.repertoire import TCRrep
+	from tcrdist.pgen import OlgaModel
+	import numpy as np
+
+	df = pd.read_csv("dash.csv")
+	tr = TCRrep(cell_df = df, 
+	            organism = 'mouse', 
+	            chains = ['alpha','beta'], 
+	            db_file = 'alphabeta_gammadelta_db.tsv',
+	            compute_distances = False)
+
+	# Load olga model as a object
+	olga_beta  = OlgaModel(chain_folder = "mouse_T_beta", recomb_type="VDJ")
+	olga_alpha = OlgaModel(chain_folder = "mouse_T_alpha", recomb_type="VJ")
+
+	# An example computing a single Pgen
+	olga_beta.compute_aa_cdr3_pgen(tr.clone_df['cdr3_b_aa'][0])
+	olga_alpha.compute_aa_cdr3_pgen(tr.clone_df['cdr3_a_aa'][0])
+
+	# An example computing multiple Pgens 
+	olga_beta.compute_aa_cdr3_pgens(tr.clone_df['cdr3_b_aa'][0:5])
+	olga_alpha.compute_aa_cdr3_pgens(tr.clone_df['cdr3_a_aa'][0:5])
+
+	# An example computing 1920 Pgens more quickly with mulitple cpus
+	import parmap
+	tr.clone_df['pgen_cdr3_b_aa'] = \
+		parmap.map(
+			olga_beta.compute_aa_cdr3_pgen, 
+			tr.clone_df['cdr3_b_aa'], 
+			pm_pbar=True, 
+			pm_processes = 2)
+
+	tr.clone_df['pgen_cdr3_a_aa'] = \
+		parmap.map(
+			olga_alpha.compute_aa_cdr3_pgen, 
+			tr.clone_df['cdr3_a_aa'], 
+			pm_pbar=True, 
+			pm_processes = 2)
+
+	"""
+	We can do something else useful. We've tweaked the original 
+	generative code in OLGA, so that you can generate CDRs,
+	given a specific TRV and TRJ. 
+
+	Note that unfortunately not all genes are recognized in default OLGA models, 
+	but many are. This gives you an idea of what you can do. Here are 10
+	CDR3s generated at random given a particular V,J usage combination
+	"""
+	np.random.seed(1)
+	olga_beta.gen_cdr3s(V = 'TRBV14*01', J = 'TRBJ2-5*01', n =10) 
+	olga_alpha.gen_cdr3s(V ='TRAV4-3*02', J ='TRAJ31*01',  n =10)
+
+	"""
+	Using this approach, we can synthesize an 100K background, 
+	with similar gene usage frequency to our actual repertoire. 
+	Note, however, that given data availability, 
+	this is currently likely the most reliable for human beta chain.
+
+	After OLGA's publication, a default mouse alpha model (mouse_T_alpha) 
+	was added to the OLGA GitHub repository. We've included that here
+	but it should be used with caution as it is missing
+	a number of commonly seen V genes.
+	"""
+	np.random.seed(1)
+	tr.synthesize_vj_matched_background(chain = 'beta')
+	"""
+	          v_b_gene    j_b_gene            cdr3_b_aa        pV        pJ       pVJ   weights      source
+	0        TRBV14*01  TRBJ2-3*01        CASSLASAETLYF  0.033721  0.092039  0.002989  0.065742  vj_matched
+	1      TRBV13-2*01  TRBJ2-3*01    CASGDAPDRTGAETLYF  0.118785  0.092039  0.010331  0.271309  vj_matched
+	2      TRBV13-3*01  TRBJ1-1*01  CASSDGFSRTGGVNTEVFF  0.074051  0.106146  0.006923  1.009124  vj_matched
+	3      TRBV13-3*01  TRBJ2-1*01       CASSDVQGGAEQFF  0.074051  0.117684  0.008915  1.021244  vj_matched
+	4      TRBV13-3*01  TRBJ2-7*01     CASSSGTGGYIYEQYF  0.074051  0.204898  0.015366  1.670224  vj_matched
+	...            ...         ...                  ...       ...       ...       ...       ...         ...
+	99995    TRBV14*01  TRBJ2-3*01  CASSPTGGAPYASAETLYF  0.033721  0.092039  0.002989  0.065742  vj_matched
+	99996    TRBV17*01  TRBJ2-5*01       CASSRDPTQDTQYF  0.028110  0.124712  0.004930  0.650360  vj_matched
+	99997    TRBV14*01  TRBJ2-3*01       CASSSTGGAETLYF  0.033721  0.092039  0.002989  0.065742  vj_matched
+	99998  TRBV13-1*01  TRBJ2-1*01      CASSDWGKDYAEQFF  0.106042  0.117684  0.013373  2.622194  vj_matched
+	99999     TRBV4*01  TRBJ2-3*01      CASSYDRGSAETLYF  0.040749  0.092039  0.002989  0.068343  vj_matched
+	"""
+	np.random.seed(1)
+	tr.synthesize_vj_matched_background(chain = 'alpha')
+	"""
+	           v_a_gene   j_a_gene        cdr3_a_aa        pV        pJ       pVJ   weights      source
+	0      TRAV12N-3*01  TRAJ34*02     CAIASNTNKVVF  0.000438  0.000088  0.000088  0.006059  vj_matched
+	1       TRAV3D-3*02  TRAJ33*01  CAVSAGADSNYQLIW  0.000088  0.000088  0.000088  0.005122  vj_matched
+	2        TRAV3-3*01  TRAJ27*01     CAVSTNTGKLTF  0.014029  0.042964  0.000877  0.277471  vj_matched
+	3        TRAV3-3*01  TRAJ26*01    CAVSHNYAQGLTF  0.014029  0.040947  0.001052  0.009155  vj_matched
+	4        TRAV3-3*01  TRAJ26*01   CAVSARNYAQGLTF  0.014029  0.040947  0.001052  0.009155  vj_matched
+	...             ...        ...              ...       ...       ...       ...       ...         ...
+	99995   TRAV3D-3*02  TRAJ21*01    CAVSVSNYNVLYF  0.000088  0.039982  0.000088  0.003758  vj_matched
+	99996    TRAV3-3*01  TRAJ43*01    CAVSENNNNAPRF  0.014029  0.022271  0.000526  0.071093  vj_matched
+	99997   TRAV3D-3*02  TRAJ26*01    CAVSGNYAQGLTF  0.000088  0.040947  0.000088  0.000296  vj_matched
+	99998    TRAV3-3*01  TRAJ26*01   CAVKGNNYAQGLTF  0.014029  0.040947  0.001052  0.009155  vj_matched
+	99999   TRAV9N-2*01  TRAJ15*01      CTYQGGRALIF  0.000088  0.043840  0.000088  0.020438  vj_matched
+	"""
+


### PR DESCRIPTION
Note that mouse default alpha currently on OLGA's GH repository does not include all V gene's in dash.csv so it is unlikely to provide reliable background repositories. We've included it here so that the code can be updated as future default (mouse_T_alpha) models become available.