### PR TITLE
Update adpt_funcs.py

### DIFF
--- a/tcrdist/adpt_funcs.py
+++ b/tcrdist/adpt_funcs.py
@@ -32,7 +32,8 @@ def import_adaptive_file(   adaptive_filename,
                             epitope = None,
                             log = True, 
                             swap_imgt_dictionary = None,
-                            additional_cols = None):
+                            additional_cols = None,
+                            use_cols =  ['bio_identity', 'productive_frequency', 'templates', 'rearrangement']):
     """
     Prepare tcrdist3 input from 2020 Adaptive File containing 'bio_identity', 'productive_frequency', 'templates', and 'rearrangement'.
 
@@ -60,13 +61,16 @@ def import_adaptive_file(   adaptive_filename,
         If None, the default dictionary adaptive_to_imgt is used
     additional_cols : None or List
         list of any additional columns you want to keep
+    use_cols : list
+        ['bio_identity', 'productive_frequency', 'templates', 'rearrangement','subject'] list of columns to retain from original input file. Add 'subject' 
+        if you wish to retain the subject.
     
     Returns 
     -------
     bulk_df : pd.DataFrame
     """
     try:
-        bulk_df = pd.read_csv(adaptive_filename, sep= sep, usecols = ['bio_identity', 'productive_frequency', 'templates', 'rearrangement'])
+        bulk_df = pd.read_csv(adaptive_filename, sep= sep, usecols = use_cols )
     except ValueError as e:
         raise Exception('Bulk Adpative TCR file was missing required columns') from e
 
@@ -100,11 +104,12 @@ def import_adaptive_file(   adaptive_filename,
     # Count number of valid seqs
     valid = np.sum(bulk_df['valid_cdr3'])
     
-    # Assign subject baesd on the < subject > argument 
-    if subject is None:
-        bulk_df['subject'] = adaptive_filename
-    else: 
-        bulk_df['subject'] = subject
+    # Assign subject baesd on the < subject > argument if not already in bulk_df
+    if subject not in bulk_df.columns:
+        if subject is None:
+            bulk_df['subject'] = adaptive_filename
+        else: 
+            bulk_df['subject'] = subject
 
     # Assign a user supplied or blank epitope baesd on the < epitope > argument 
     if epitope is None:


### PR DESCRIPTION
To Address issue #42

We designed this with one subject per file in mind. 

If I understand, the file Tissue_Bioidentity_TCRdist.tsv have multiple subject ids that you want to retain 

Once all the tests pass and this PR has been added to master:     

you can reinstall with 

pip install git+https://github.com/kmayerb/tcrdist3.git@master

Then you can add 'subject' to the new argument: 

use_cols : list
        ['bio_identity', 'productive_frequency', 'templates', 'rearrangement', 'subject'] list of columns to retain from original input file. Add 'subject' 
        if you wish to retain the subject or leave it blank to use filename as before.