### PR TITLE
Added a missing argument when calling _synthesize_vj_matched_background

### DIFF
--- a/tcrdist/background.py
+++ b/tcrdist/background.py
@@ -398,7 +398,7 @@ def _synthesize_human_beta_vj_background(ts,fn = None, df = None, n = 100000):
     # Combine
     return df_vj_bkgd
 
-def _synthesize_human_alpha_vj_background(ts,fn = None, df = None):
+def _synthesize_human_alpha_vj_background(ts,fn = None, df = None, n=100000):
     """
     _build_vj_background
 
@@ -435,12 +435,12 @@ def _synthesize_human_alpha_vj_background(ts,fn = None, df = None):
     #   Note: <size> aregument should be greater than desired, because Olga can return none due to non-productive CDR3s.
     df_vj_bkgd = make_vj_matched_background(ts = ts,
         gene_usage_counter = gene_usage_counter,    
-        size = 150000, 
+        size = int(n * 1.5),
         recomb_type="VJ", 
         chain_folder = "human_T_alpha",
         cols = ['v_a_gene', 'j_a_gene', 'cdr3_a_aa'])
     # Sample to get the desired number of TCRs from teh v,j matched set
-    df_vj_bkgd = df_vj_bkgd.sample(100000, random_state = 1).reset_index(drop = True)
+    df_vj_bkgd = df_vj_bkgd.sample(n, random_state = 1).reset_index(drop = True)
     print("CALCULATE INVERSE PROBABILITY WEIGHT ADJUSTMENT.")
     # Calculate the invese weighting adjustmetn
     df_vj_bkgd['weights'] = calculate_adjustment(df = df_vj_bkgd, adjcol = "pVJ", cols = ['v_a_gene','j_a_gene'])
@@ -449,7 +449,7 @@ def _synthesize_human_alpha_vj_background(ts,fn = None, df = None):
     return df_vj_bkgd
 
 
-def _synthesize_mouse_beta_vj_background(ts, fn = None, df = None):
+def _synthesize_mouse_beta_vj_background(ts, fn = None, df = None, n=100000):
     """
     _build_vj_background
 
@@ -486,12 +486,12 @@ def _synthesize_mouse_beta_vj_background(ts, fn = None, df = None):
     #   Note: <size> aregument should be greater than desired, because Olga can return none due to non-productive CDR3s.
     df_vj_bkgd = make_vj_matched_background(ts = ts,
         gene_usage_counter = gene_usage_counter,    
-        size = 150000, 
+        size = int(n * 1.5),
         recomb_type="VDJ", 
         chain_folder = "mouse_T_beta",
         cols = ['v_b_gene', 'j_b_gene', 'cdr3_b_aa'])
     # Sample to get the desired number of TCRs from teh v,j matched set
-    df_vj_bkgd = df_vj_bkgd.sample(100000, random_state = 1).reset_index(drop = True)
+    df_vj_bkgd = df_vj_bkgd.sample(n, random_state = 1).reset_index(drop = True)
     print("CALCULATE INVERSE PROBABILITY WEIGHT ADJUSTMENT.")
     # Calculate the invese weighting adjustmetn
     df_vj_bkgd['weights'] = calculate_adjustment(df = df_vj_bkgd, adjcol = "pVJ")
@@ -499,7 +499,7 @@ def _synthesize_mouse_beta_vj_background(ts, fn = None, df = None):
     # Combine
     return df_vj_bkgd
 
-def _synthesize_mouse_alpha_vj_background(ts, fn = None, df = None):
+def _synthesize_mouse_alpha_vj_background(ts, fn = None, df = None, n=100000):
     """
     _build_vj_background
 
@@ -536,12 +536,12 @@ def _synthesize_mouse_alpha_vj_background(ts, fn = None, df = None):
     #   Note: <size> aregument should be greater than desired, because Olga can return none due to non-productive CDR3s.
     df_vj_bkgd = make_vj_matched_background(ts = ts,
         gene_usage_counter = gene_usage_counter,    
-        size = 150000, 
+        size = int(n * 1.5),
         recomb_type="VJ", 
         chain_folder = "mouse_T_alpha",
         cols = ['v_a_gene', 'j_a_gene', 'cdr3_a_aa'])
     # Sample to get the desired number of TCRs from teh v,j matched set
-    df_vj_bkgd = df_vj_bkgd.sample(100000, random_state = 1, replace = True).reset_index(drop = True)
+    df_vj_bkgd = df_vj_bkgd.sample(n, random_state = 1, replace = True).reset_index(drop = True)
     print("CALCULATE INVERSE PROBABILITY WEIGHT ADJUSTMENT.")
     print(df_vj_bkgd)
     # Calculate the invese weighting adjustmetn

--- a/tcrdist/repertoire.py
+++ b/tcrdist/repertoire.py
@@ -701,7 +701,7 @@ class TCRrep:
             if self.organism == "human":
                 vj_background = _synthesize_human_beta_vj_background(ts = ts, df = self.clone_df, n = n)
             elif self.organism == "mouse":
-                vj_background = _synthesize_mouse_beta_vj_background(ts = ts, df = self.clone_df)
+                vj_background = _synthesize_mouse_beta_vj_background(ts = ts, df = self.clone_df, n = n)
         # TODO: ADD OTHER OPTIONS
         elif chain == "alpha":
             if ts is None:
@@ -709,10 +709,10 @@ class TCRrep:
                 ts = get_stratified_gene_usage_frequency(ts = ts, replace = True) 
             if self.organism == "human":
                 #raise ValueError("TODO: FUTURE VERSIONS NEED ALPHA(HUMAN)")
-                vj_background = _synthesize_human_alpha_vj_background(ts = ts, df = self.clone_df)
+                vj_background = _synthesize_human_alpha_vj_background(ts = ts, df = self.clone_df, n = n)
             elif self.organism == "mouse":
                 #raise ValueError("TODO: FUTURE VERSIONS NEED ALPHA(MOUSE)")
-                vj_background = _synthesize_mouse_alpha_vj_background(ts = ts, df = self.clone_df)
+                vj_background = _synthesize_mouse_alpha_vj_background(ts = ts, df = self.clone_df, n = n)
         return vj_background   
 
 


### PR DESCRIPTION
In the current code base only in the case of chain="beta" the `n`
argument was properly propogated. This commit fixed this by passing
the argument to the underline function `_synthesize_vj_matched_background`. 
Similar to what was done for the case of beta chain.

Signed-off-by: Yossi Eliaz <eliaz123@gmail.com>