### PR TITLE
Provide an alternative bkgd_cntl_nn function (bkgd_cntl_nn3), with reduced memory usage and increased speed

### DIFF
--- a/tcrdist/neighbors.py
+++ b/tcrdist/neighbors.py
@@ -7,10 +7,11 @@ This module contas
 import numpy as np 
 import pandas as pd
 import parmap
+import re
 import scipy.sparse
 import warnings
 #from tcrdist.repertoire import TCRrep
-from tcrdist.regex import _index_to_regex_str, _index_to_seqs, _multi_regex_precompiled 
+from tcrdist.regex import _index_to_regex_str, _index_to_seqs, _multi_regex, _multi_regex_weighted
 from scipy.stats import chi2_contingency
 
 
@@ -334,18 +335,19 @@ def bkgd_cntl_nn2( tr,
         print("TESTING REGEX FOR EACH META-CLONOTYPE")
         # THIS INVOLVES TESTING REGEX AGAINST TARGET AND BACKGROUND
         # Test regex against backgound
-        rs = [re.comp(r) for r in centers_df['regex'].to_list()]
+        rs = centers_df['regex'].to_list()
         bkgd_cdr3 = tr_background.clone_df[cdr3_col].to_list()
         target_cdr3 = tr.clone_df[cdr3_col].to_list()
-        target_re_hits = parmap.map(_multi_regex_precompiled, rs, bkgd_cdr3 = target_cdr3 , pm_pbar = True, pm_processes = ncpus) #modified _multi_regex() returns tuple
-        centers_df['target_re_hits'] = [h[0] for h in target_re_hits]
-        bkgd_re_hits = parmap.map(_multi_regex_precompiled, rs, bkgd_cdr3 = bkgd_cdr3, pm_pbar = True, pm_processes = ncpus) #modified _multi_regex() returns tuple
-        centers_df['bkgd_re_hits'] = [h[0] for h in bkgd_re_hits]
-        centers_df['bkgd_re_weighted_hits']  = [h[1] for h in bkgd_re_hits]
-        rm(target_re_hits)
-        rm(bkgd_re_hits)
+        target_regex_hits = parmap.map(_multi_regex, rs, bkgd_cdr3 = target_cdr3 , pm_pbar = True, pm_processes = ncpus)
+        target_re_hits = [np.sum([1 if (x is not None) else 0 for x in l]) for l in target_regex_hits ]
+        centers_df['target_re_hits'] = target_re_hits
+        bkgd_regex_hits = parmap.map(_multi_regex, rs, bkgd_cdr3 = bkgd_cdr3, pm_pbar = True, pm_processes = ncpus)
+        bkgd_re_hits = [np.sum([1 if (x is not None) else 0 for x in l]) for l in bkgd_regex_hits]
+        centers_df['bkgd_re_hits'] = bkgd_re_hits
+        bkgd_weighted_re_hits = [np.sum(np.array([1 if (x is not None) else 0 for x in l]) * (weights)) for l in bkgd_regex_hits] 
         # Compute Relative Rates
         print("COMPUTING WEIGHTED ODDS RATIO, RELATIVE RATES FOR EACH REGEX")
+        centers_df['bkgd_re_weighted_hits'] = bkgd_weighted_re_hits 
         centers_df['TR_re'] = [compute_rate(pos=r['target_re_hits'], neg=n1-r['target_re_hits']) for i,r in centers_df.iterrows()]
         centers_df['BR_re_weighted'] = [compute_rate(pos=r['bkgd_re_weighted_hits'], 
                                      neg=n2-r['bkgd_re_weighted_hits']) for i,r in centers_df.iterrows()]
@@ -364,6 +366,280 @@ def bkgd_cntl_nn2( tr,
 
     return centers_df #, thresholds, ecdfs
 
+
+#this version modified to use the new _multi_regex_weighted() function, which saves memory by summing hits (and 
+#   weighted hits) with the function, so that the full lists of regex hits do not have to be stored in memory at the
+#   same time.  It also takes a precompiled regex expression (for speed).
+def bkgd_cntl_nn3( tr, 
+                   tr_background,
+                   weights = None,
+                   ctrl_bkgd = 10**-5, 
+                   col = 'cdr3_b_aa',
+                   add_cols = ['v_b_gene', 'j_b_gene'],
+                   pw_mat_str = 'pw_beta',
+                   rw_mat_str = 'rw_beta',
+                   ncpus = 4,
+                   include_seq_info= True,
+                   thresholds = [x for x in range(0,50,2)],
+                   generate_regex = True,
+                   test_regex = True,
+                   beta_re = 1,
+                   beta_dist = 1,
+                   forced_max_radius = None):   
+    
+    """
+    bkgd_cntl_nn3 stands for background controlled nearest neighbors. 
+    tr : tcrdist.repertoire.TCRrep
+        TCRrep instance with clone_df of target data
+    tr_background : tcrdist.repertoire.TCRrep
+        TCRrep instance with clone_df of bulk data
+    ctrl_bkgd : float
+        Default is 2*10**-5, the acceptable level of background neighbror 
+    col : str
+        Default is cdr3_b_aa', the column containing CDR3 string
+    add_cols  : list
+        Extra columns from clone_df to include in centers_df['v_b_gene', 'j_b_gene'],
+    ncpus : int
+        e.g., 4, passed to pm_processes when using parmap   
+    include_seq_info : bool 
+        If True, returned DataFrame <centers_df> will include ['target_neighbors', 'target_seqs',
+        'background_neighbors','background_seqs','background_v', 'background_j']
+        as columns in centers_df DataFrame returned by this function. 
+        This allows for inspection of sequences found in both the antigen enriched repertoire and supplied
+        background.
+    thresholds : list
+        Default is [x for x in range(0,50,2)] indicating tcrdist thresholds to compute 
+        a ecdf over.
+    generate_regex : bool
+        if True, generate a regex pattern capturing most if not all of 
+        sequences in the neigbhorhood
+    test_regex = True
+        if True, test regex against both CDR3 in target and background
+    beta_re : int or float
+        for joint chi2, weight for regex based portion
+    beta_dist : int of float
+        for joint chi2, weight for distance based portion
+    forced_max_radius : int or None
+        if not None, radius cannot exceed this amount
+    
+    Returns 
+    -------
+    centers_df: DataFrame
+    
+    Notes
+    -----
+    The logic behind this function is that we want to find radi that 
+    are appropriate for each TCR in a epitope-specific target set 
+    that control the frequency of finding neighbors in a background set. 
+    For instance, a TCR with common V gene usage and a high probabililty 
+    of generation CDR3, will potentially have many nieghbors in a 
+    pre-selection background set, whereas a TCR with rare gene usage 
+    and a low probability of generation CDR3 can acomodate a larger 
+    neighborhood radi. 
+    The result dataframe can be sorted to find TCRs that anchor 
+    a nieghborhood of TCRs including the most epitope specific
+    nieghbors. We hypothesis that these TCRs are more likely to serve as a useful 
+    biomarker for searching for biochemically similar TCRs in unlabeled
+    datasets. 
+    """ 
+    
+        # <cdr_col> usually 'cdr3_b_aa', we save this for later 
+    cdr3_col = str(col)
+        # <pw_mat> pairwise matrix, typically the network between antigen enriched clones
+    pw_mat = getattr(tr, pw_mat_str)# defaults to 'pw_beta',
+        # <rw_mat> rectangular matrix, typically the network betwen antigen enriched and bulk clones
+    rw_mat = getattr(tr, rw_mat_str)# defaults to 'rw_beta',
+        # remind the user if they are using sparse or dense matrices as input
+    print(f"PW MATRIX TYPE = {type(pw_mat)}")
+    print(f"RW MATRIX TYPE = {type(rw_mat)}")
+        # <max_radius> int describing the highest distances, only will be needed for sparse impementation
+        # <thresholds> array of thresholds radii to consider 
+    thresholds = np.unique(thresholds)
+    max_radius = thresholds.max() + 1
+        # <weights> inverse probability weights, if none provided assume all are one
+    if weights is None:
+        warnings.warn("No weights provided trying to use tr_background.clone_df.weights")
+        if 'weights' in tr_background.clone_df.columns:
+            warnings.warn("USING tr_background.clone_df.weights")
+            weights = tr_background.clone_df['weights']
+        else:
+            warnings.warn("SOMETHING IS PROBABLY WRONG!!!!. You don't have a 'weights' column in your tr_background clone_df, setting to 1, results could be biased if this data is V-J matched")
+            weights = np.ones(rw_mat.shape[1])
+    thresholds = np.unique(thresholds)
+        # for each TCR, we calculate a empirical cummulative 
+        # density function along a range of threshold radii
+    
+    from tcrdist.ecdf import distance_ecdf
+    thresholds, ecdfs2 = distance_ecdf(pwrect =rw_mat, 
+      thresholds = thresholds, 
+      weights= weights, 
+      pseudo_count=0, 
+      skip_diag = False, 
+      absolute_weight = True)
+    
+    ecdfs2 = [pd.Series(x, index = thresholds) for x in ecdfs2]
+    max_radi2 = [x[x<=ctrl_bkgd].last_valid_index() for x in ecdfs2]
+    # TO SOLVE NOTABLE BUG IN THE ABOVE LINE!! If a radius is None (the next line will fail, thus set Nones to 0.
+    max_radi2 = [x if (x is not None) else 0 for x in max_radi2]
+    
+    if forced_max_radius is not None:
+        max_radi2 = [min(x,forced_max_radius) for x in max_radi2]
+    
+    max_radi = max_radi2
+        # <target_hits> number of hits within the antigen enriched repertoire at the control radius 
+    if scipy.sparse.issparse(pw_mat):
+        # sparse implementation, relies on _todense_row (see above in this module)
+        target_hits    = [np.sum(_todense_row(pw_mat[i,:], max_radius )[0] <= t) for t,i in zip(max_radi, range(0,pw_mat.shape[0]))]
+    else: 
+        target_hits    = [np.sum(pw_mat[i,:] <= t) for t,i in zip(max_radi, range(0,pw_mat.shape[0]))]
+        # <bkgd_hits>  number of hits within the bulk unenriched repertoire at the control radius 
+        # <bkgd_hits_weighted> number of hits when inverse probability weights are applied
+    if scipy.sparse.issparse(rw_mat):
+        bkgd_hits          = [np.sum(_todense_row(rw_mat[i,:], max_radius)[0] <= t) for t,i in zip(max_radi, range(0,rw_mat.shape[0]))]
+        bkgd_hits_weighted = [np.sum(1*(_todense_row(rw_mat[i,:], max_radius)[0] <= t) * (weights)) for t,i in zip(max_radi, range(0,rw_mat.shape[0]))]
+    else:
+        bkgd_hits      = [np.sum(rw_mat[i,:] <= t) for t,i in zip(max_radi, range(0,rw_mat.shape[0]))]
+        bkgd_hits_weighted = [np.sum(1*(rw_mat[i,:] <= t) * (weights)) for t,i in zip(max_radi, range(0,rw_mat.shape[0]))]
+    
+        # <bkdg_total> number of rows in background
+    bkgd_total = rw_mat.shape[1]
+        # <bkgd_weighted_total > 
+    bkgd_weighted_total = rw_mat.shape[1] # In modern, implemenation demoninator is simply length not np.sum(weights)
+        # <ctrl> divide total hits by total posible hits
+    ctrl = np.array(bkgd_hits) / bkgd_total 
+        # <ctrl_weighted> divide weighted hits byt total possible hits to approximate expected frequency in a real repertoire
+    ctrl_weighted= np.array(bkgd_hits_weighted)/bkgd_weighted_total 
+        # <center_df> this is the kernal of dataframe
+    
+        # we typically want pgen in our analysis so
+    if f'pgen_{col}' in tr.clone_df.columns:
+        centers_df = pd.DataFrame({col: tr.clone_df[col].copy(),
+                  add_cols[0] : tr.clone_df[add_cols[0]].copy(), 
+                  add_cols[1] : tr.clone_df[add_cols[1]].copy(), 
+                  'pgen' : tr.clone_df[f'pgen_{col}'],
+                  'radius': max_radi,
+                  'target_hits' : target_hits, 
+                  'bkgd_hits': bkgd_hits,
+                  'bkgd_hits_weighted': bkgd_hits_weighted,
+                  'bkgd_total' :  bkgd_total,
+                  'ctrl' : ctrl,
+                  'ctrl_weighted' : ctrl_weighted})
+    else: 
+        print("YOU DID NOT PRECALCULATE OPTIONAL PGENS SEE auto_pgen(TCRrep) NEXT TIME")
+        centers_df = pd.DataFrame({col: tr.clone_df[col].copy(),
+                  add_cols[0] : tr.clone_df[add_cols[0]].copy(), 
+                  add_cols[1] : tr.clone_df[add_cols[1]].copy(), 
+                  'radius': max_radi,
+                  'target_hits' : target_hits, 
+                  'bkgd_hits': bkgd_hits,
+                  'bkgd_hits_weighted': bkgd_hits_weighted,
+                  'bkgd_total' :  bkgd_total,
+                  'ctrl' : ctrl,
+                  'ctrl_weighted' : ctrl_weighted})
+    
+    # Total bakground counts
+    n1 = tr.clone_df.shape[0]   
+    n2 = bkgd_weighted_total 
+    print(f"ANTIGEN-ENRICHED CLONES : {n1}")
+    print(f"BULK  BACKGROUND CLONES : {n2}")  
+    print("COMPUTING WEIGHTED ODDS RATIO, RELATIVE RATE")
+    centers_df['target_misses'] = centers_df['target_hits'].apply(lambda x : n1-x)
+    centers_df['TR'] = [compute_rate(pos=r['target_hits'], neg=(n1-r['target_hits'])) for i,r in centers_df.iterrows()]
+    centers_df['TR2'] = [compute_rate(pos=r['target_hits'], neg=r['target_misses']) for i,r in centers_df.iterrows()]
+    centers_df['BR_weighted'] = [compute_rate(pos=r['bkgd_hits_weighted'], 
+                                    neg=n2-r['bkgd_hits_weighted']) for i,r in centers_df.iterrows()]
+    centers_df['RR_weighted'] = centers_df['TR']/centers_df['BR_weighted']
+    centers_df['OR_weighted'] =[compute_odds_ratio(pos=r['target_hits'], 
+                                       neg=n1-r['target_hits'], 
+                                       bpos=r['bkgd_hits_weighted'], 
+                                       bneg= n2-r['bkgd_hits_weighted'], ps = 1) for i,r in centers_df.iterrows()]
+    print("COMPUTING CHI-SQUARE STATISTIC BASED ON WEIGHTED DISTANCE HITS <chi2dist>")
+    centers_df['chi2dist'] = [chi2_contingency(np.array(
+            [[1+r['target_hits'], 1+n1-r['target_hits']],[1+r['bkgd_hits_weighted'], 1+n2-r['bkgd_hits_weighted']]]))[0] for _,r in centers_df.iterrows() ]
+    
+    if include_seq_info:
+        print("INCLUDING SEQ INFO")
+        if scipy.sparse.issparse(pw_mat):
+            target_neighbors = [list((_todense_row(pw_mat[i,:], max_radius)[0] <= t).nonzero()[0]) for t,i in zip(max_radi, range(0,pw_mat.shape[0]))]
+        else:
+            target_neighbors = [list((pw_mat[i,:] <= t).nonzero()[0]) for t,i in zip(max_radi, range(0,pw_mat.shape[0]))]
+        
+        centers_df['target_neighbors'] = target_neighbors 
+        centers_df['target_seqs'] = [tr.clone_df.loc[ar,col].to_list() for ar in target_neighbors]
+        if scipy.sparse.issparse(rw_mat):
+            background_neighbors = [list((_todense_row(rw_mat[i,:], max_radius)[0] <= t).nonzero()[0]) for t,i in zip(max_radi, range(0,pw_mat.shape[0]))]
+        else:
+            background_neighbors = [list((rw_mat[i,:] <= t).nonzero()[0]) for t,i in zip(max_radi, range(0,pw_mat.shape[0]))]
+        
+        
+        centers_df['background_neighbors'] = background_neighbors
+        #col = "cdr3_b_aa"
+        centers_df['background_seqs'] = [tr_background.clone_df.loc[ar,col].to_list() for ar in background_neighbors]
+        vcol = add_cols[0] #v_b_gene 
+        centers_df['background_v'] = [tr_background.clone_df.loc[ar,vcol].to_list() for ar in background_neighbors]
+        jcol = add_cols[1] #j_b_gene
+        centers_df['background_j'] = [tr_background.clone_df.loc[ar,jcol].to_list() for ar in background_neighbors]
+        adjcol  = 'adj_freq_pVJ'
+        if adjcol in tr_background.clone_df.columns:
+            centers_df['adj_freq'] = [tr_background.clone_df.loc[ar,adjcol].to_list() for ar in background_neighbors]
+    
+    if generate_regex:
+        print("GENERATING REGEX FOR EACH META-CLONOTYPE")
+        #cdr3_col = "cdr3_b_aa"
+        centers_df['regex'] = [_index_to_regex_str(ind = r['target_neighbors'], 
+                clone_df = tr.clone_df, 
+                pwmat = None, 
+                col = cdr3_col, 
+                centroid = tr.clone_df[cdr3_col][i],
+                ntrim = 3,
+                ctrim = 2,
+                max_ambiguity = 5) for i,r in centers_df.iterrows()]
+    
+    if test_regex:
+        print("TESTING REGEX FOR EACH META-CLONOTYPE")
+        # THIS INVOLVES TESTING REGEX AGAINST TARGET AND BACKGROUND
+        # Test regex against backgound
+        rs = [re.compile(a) for a in centers_df['regex']] #precompile regex (for speed)
+        bkgd_cdr3 = tr_background.clone_df[cdr3_col].to_list()
+        target_cdr3 = tr.clone_df[cdr3_col].to_list()
+        target_re_hits = parmap.map(
+                                    _multi_regex_weighted,
+                                    rs,
+                                    bkgd_cdr3 = target_cdr3,
+                                    pm_processes = ncpus,
+                                    pm_pbar=True
+                                    )
+        target_re_hits = [x[0] for x in target_re_hits] #new; no background weighting, so want the first element of each tuple
+        centers_df['target_re_hits'] = target_re_hits
+        bkgd_combined_hits = parmap.map( #new
+                                _multi_regex_weighted, 
+                                rs, 
+                                bkgd_cdr3 = bkgd_cdr3, 
+                                weights = weights, 
+                                pm_processes = ncpus,
+                                pm_pbar=True
+                                ) 
+        bkgd_re_hits = [x[0] for x in bkgd_combined_hits] #new
+        bkgd_weighted_re_hits = [x[1] for x in bkgd_combined_hits] #new
+        centers_df['bkgd_re_hits'] = bkgd_re_hits
+        # Compute Relative Rates
+        print("COMPUTING WEIGHTED ODDS RATIO, RELATIVE RATES FOR EACH REGEX")
+        centers_df['bkgd_re_weighted_hits'] = bkgd_weighted_re_hits 
+        centers_df['TR_re'] = [compute_rate(pos=r['target_re_hits'], neg=n1-r['target_re_hits']) for i,r in centers_df.iterrows()]
+        centers_df['BR_re_weighted'] = [compute_rate(pos=r['bkgd_re_weighted_hits'], 
+                                     neg=n2-r['bkgd_re_weighted_hits']) for i,r in centers_df.iterrows()]
+        centers_df['RR_re_weighted'] = centers_df['TR']/centers_df['BR_re_weighted']
+        centers_df['OR_re_weighted'] =[compute_odds_ratio(pos=r['target_re_hits'], 
+                                       neg=n1-r['target_re_hits'], 
+                                       bpos=r['bkgd_re_weighted_hits'], 
+                                       bneg= n2-r['bkgd_re_weighted_hits'], ps = 1) for i,r in centers_df.iterrows()]
+        print("COMPUTING CHI-SQUARE STATISTIC BASED ON WEIGHTED REGEX HITS <chi2re>")
+        centers_df['chi2re'] = [chi2_contingency(np.array(
+            [[1+r['target_re_hits'], 1+n1-r['target_re_hits']],[1+r['bkgd_re_weighted_hits'], 1+n2-r['bkgd_re_weighted_hits']]]))[0] for _,r in centers_df.iterrows() ]
+        print(f"COMPUTING JOINT CHI-SQUARE STATISTIC <chi2joint>BASED ON WEIGHTED REGEX HITS {beta_re} * <chi2re> + {beta_dist} * <chi2dist")
+        centers_df['chi2joint'] = [beta_re  * r['chi2re'] + beta_dist* r['chi2dist'] for _,r in centers_df.iterrows() ]
+    
+    return centers_df #, thresholds, ecdfs
 
 
 

--- a/tcrdist/neighbors.py
+++ b/tcrdist/neighbors.py
@@ -337,11 +337,11 @@ def bkgd_cntl_nn2( tr,
         rs = centers_df['regex'].to_list()
         bkgd_cdr3 = tr_background.clone_df[cdr3_col].to_list()
         target_cdr3 = tr.clone_df[cdr3_col].to_list()
-        target_regex_hits = parmap.map(_multi_regex, rs, bkgd_cdr3 = target_cdr3 , pm_pbar = True, pm_processes = ncpus)
-        target_re_hits = [np.sum([1 if (x is not None) else 0 for x in l]) for l in target_regex_hits ]
+        target_re_hits = parmap.map(_multi_regex, rs, bkgd_cdr3 = target_cdr3 , pm_pbar = True, pm_processes = ncpus) #modified _multi_regex() returns np.sum
+        #target_re_hits = [np.sum([1 if (x is not None) else 0 for x in l]) for l in target_regex_hits ]
         centers_df['target_re_hits'] = target_re_hits
-        bkgd_regex_hits = parmap.map(_multi_regex, rs, bkgd_cdr3 = bkgd_cdr3, pm_pbar = True, pm_processes = ncpus)
-        bkgd_re_hits = [np.sum([1 if (x is not None) else 0 for x in l]) for l in bkgd_regex_hits]
+        bkgd_re_hits = parmap.map(_multi_regex, rs, bkgd_cdr3 = bkgd_cdr3, pm_pbar = True, pm_processes = ncpus) #modified _multi_regex() returns np.sum
+        #bkgd_re_hits = [np.sum([1 if (x is not None) else 0 for x in l]) for l in bkgd_regex_hits]
         centers_df['bkgd_re_hits'] = bkgd_re_hits
         bkgd_weighted_re_hits = [np.sum(np.array([1 if (x is not None) else 0 for x in l]) * (weights)) for l in bkgd_regex_hits] 
         # Compute Relative Rates

--- a/tcrdist/neighbors.py
+++ b/tcrdist/neighbors.py
@@ -10,7 +10,7 @@ import parmap
 import scipy.sparse
 import warnings
 #from tcrdist.repertoire import TCRrep
-from tcrdist.regex import _index_to_regex_str, _index_to_seqs, _multi_regex 
+from tcrdist.regex import _index_to_regex_str, _index_to_seqs, _multi_regex_precompiled 
 from scipy.stats import chi2_contingency
 
 

--- a/tcrdist/regex.py
+++ b/tcrdist/regex.py
@@ -136,13 +136,19 @@ def _index_to_regex_str(ind,
 	return(regex_str)
 
 
-def _multi_regex(regex , bkgd_cdr3):
+def _multi_regex_precompiled(regex , bkgd_cdr3, weights=None):
 	"""
-	Search a regex pattern in a list of string 
+	Search a pre-compiled regex pattern in a list of strings
+	Optionally applies weights
+	Returns a tuple giving the number of hits and sums of the weights of the hits
 	"""
-	result = [re.search(string = s, pattern = regex ) for s in bkgd_cdr3] 
-	result = [1 if (x is not None) else 0 for x in result] #produces 0 rather than None
-	return np.sum(result) #modified to return the sum, as no need to store the whole array in RAM
+	result = [regex.search(string = s) for s in bkgd_cdr3]
+	result = np.array([True if (x is not None) else False for x in result])
+	if type(weights) is type(None):
+		return(np.sum(result),None)
+	else:
+		return(np.sum(result),np.sum(weights[result]))
+
 
 def _index_to_seqs(ind, clone_df, col):
 	dfnode   = clone_df.iloc[ind,].copy()

--- a/tcrdist/regex.py
+++ b/tcrdist/regex.py
@@ -141,8 +141,8 @@ def _multi_regex(regex , bkgd_cdr3):
 	Search a regex pattern in a list of string 
 	"""
 	result = [re.search(string = s, pattern = regex ) for s in bkgd_cdr3] 
-	result = [1 if (x is not None) else None for x in result]
-	return result
+	result = [1 if (x is not None) else 0 for x in result] #produces 0 rather than None
+	return np.sum(result) #modified to return the sum, as no need to store the whole array in RAM
 
 def _index_to_seqs(ind, clone_df, col):
 	dfnode   = clone_df.iloc[ind,].copy()

--- a/tcrdist/regex.py
+++ b/tcrdist/regex.py
@@ -136,19 +136,13 @@ def _index_to_regex_str(ind,
 	return(regex_str)
 
 
-def _multi_regex_precompiled(regex , bkgd_cdr3, weights=None):
+def _multi_regex(regex , bkgd_cdr3):
 	"""
-	Search a pre-compiled regex pattern in a list of strings
-	Optionally applies weights
-	Returns a tuple giving the number of hits and sums of the weights of the hits
+	Search a regex pattern in a list of string 
 	"""
-	result = [regex.search(string = s) for s in bkgd_cdr3]
-	result = np.array([True if (x is not None) else False for x in result])
-	if type(weights) is type(None):
-		return(np.sum(result),None)
-	else:
-		return(np.sum(result),np.sum(weights[result]))
-
+	result = [re.search(string = s, pattern = regex ) for s in bkgd_cdr3] 
+	result = [1 if (x is not None) else 0 for x in result] #produces 0 rather than None
+	return np.sum(result) #modified to return the sum, as no need to store the whole array in RAM
 
 def _index_to_seqs(ind, clone_df, col):
 	dfnode   = clone_df.iloc[ind,].copy()

--- a/tcrdist/regex.py
+++ b/tcrdist/regex.py
@@ -148,3 +148,15 @@ def _index_to_seqs(ind, clone_df, col):
 	dfnode   = clone_df.iloc[ind,].copy()
 	seqs = dfnode[col].to_list()
 	return seqs 
+
+
+def _multi_regex_weighted(regex , bkgd_cdr3, weights=None):
+    """
+    Search a regex pattern in a list of strings
+    Takes a complied regex and returns a tuple (number of hits, weighted number of hits)
+    """
+    result = np.array([True if regex.search(s) else False for s in bkgd_cdr3])
+    if type(weights) is type(None):
+        return(np.sum(result),None)
+    else:
+        return(np.sum(result),np.sum(weights[result]))

--- a/tcrdist/regex.py
+++ b/tcrdist/regex.py
@@ -141,8 +141,8 @@ def _multi_regex(regex , bkgd_cdr3):
 	Search a regex pattern in a list of string 
 	"""
 	result = [re.search(string = s, pattern = regex ) for s in bkgd_cdr3] 
-	result = [1 if (x is not None) else 0 for x in result] #produces 0 rather than None
-	return np.sum(result) #modified to return the sum, as no need to store the whole array in RAM
+	result = [1 if (x is not None) else None for x in result]
+	return result
 
 def _index_to_seqs(ind, clone_df, col):
 	dfnode   = clone_df.iloc[ind,].copy()

--- a/tcrdist/tests/test_bkgd_cntl_nn3_vs_bkgd_cntl_nn2.py
+++ b/tcrdist/tests/test_bkgd_cntl_nn3_vs_bkgd_cntl_nn2.py
@@ -1,0 +1,120 @@
+import os
+import random
+import dill
+import re
+import parmap
+import timeit
+import pandas as pd
+import numpy as np 
+from tcrdist.repertoire import TCRrep
+import scipy.sparse
+from tcrdist.regex import _index_to_regex_str, _index_to_seqs 
+from tcrdist.neighbors import _todense_row, compute_rate, compute_odds_ratio, bkgd_cntl_nn2, bkgd_cntl_nn3
+from scipy.stats import chi2_contingency
+from inspect import getfile
+
+def test_bkgd_cntl_nn2_setup():
+	random.seed(1)
+	
+	tcrdist_path        =   os.path.split(getfile(TCRrep))[0]
+	output_stem         =   'm60_test_main_version'
+	
+	fn_background       =   'm60_bkgd_test_input.csv'
+	fn_background       =   os.path.join(tcrdist_path, 'data', 'covid19', fn_background)
+	df_background       =   pd.read_csv(fn_background)
+	
+	#if there is no weights column, generate some random weights
+	if 'weights' not in df_background.columns:
+		df_background['weights'] = [random.random() for i in df_background.iloc[:,1]]
+	
+	tr_background       =   TCRrep( cell_df = df_background.copy(), 
+									organism = "human", 
+									chains= ['beta'], 
+									compute_distances = False)
+	
+	fn_test             =  'm60_test_input.csv'
+	fn_test             =   os.path.join(tcrdist_path, 'data', 'covid19', fn_test)
+	df_test             =   pd.read_csv(fn_test)
+	df_test             =   df_test[['v_b_gene', 'j_b_gene', 'cdr3_b_aa']]
+	tr                  =   TCRrep(	cell_df = df_test.copy(), 
+									organism = 'human', 
+									chains = ['beta'], 
+									db_file = 'alphabeta_gammadelta_db.tsv',
+									store_all_cdr = False,
+									compute_distances = True)
+	
+	tr.compute_rect_distances(df = tr.clone_df, 
+							  df2 = tr_background.clone_df, 
+							  store = False)
+	
+	assert tr.rw_beta.shape[0] == tr.clone_df.shape[0]
+	
+	with open('{}.tr.dill'.format(output_stem),'wb') as handle:
+		dill.dump(tr,handle)
+	
+	with open('{}.tr_background.dill'.format(output_stem),'wb') as handle:
+		dill.dump(tr_background,handle)
+
+
+def test_bkgd_cntl_nn2(ncpus=2):
+	output_stem         =   'm60_test_main_version'
+	
+	with open('{}.tr.dill'.format(output_stem),'rb') as handle:
+		tr = dill.load(handle)
+	
+	with open('{}.tr_background.dill'.format(output_stem),'rb') as handle:
+		tr_background = dill.load(handle)
+	
+	centers_df = bkgd_cntl_nn2(	tr = tr, 
+								tr_background = tr_background,
+								ctrl_bkgd = 10**-6, 
+								weights = tr_background.clone_df.weights,
+								col = 'cdr3_b_aa',
+								ncpus = ncpus,
+								thresholds = [x for x in range(0,50,2)], 
+								generate_regex = True, 
+								test_regex = True)
+	
+	out_fn_center_df		     = '{}.bkgd_cntl_nn2.centers_df.csv'.format(output_stem)
+	centers_df.to_csv(out_fn_center_df, index = False)
+
+
+def test_bkgd_cntl_nn3(ncpus=2):	
+	output_stem         =   'm60_test_main_version'
+	
+	with open('{}.tr.dill'.format(output_stem),'rb') as handle:
+		tr = dill.load(handle)
+	
+	with open('{}.tr_background.dill'.format(output_stem),'rb') as handle:
+		tr_background = dill.load(handle)
+	
+	centers_df = bkgd_cntl_nn3(	tr = tr, 
+								tr_background = tr_background,
+								ctrl_bkgd = 10**-6, 
+								weights = tr_background.clone_df.weights,
+								col = 'cdr3_b_aa',
+								ncpus = ncpus,
+								thresholds = [x for x in range(0,50,2)], 
+								generate_regex = True, 
+								test_regex = True)
+	
+	out_fn_center_df			= '{}.bkgd_cntl_nn3.centers_df.csv'.format(output_stem)
+	centers_df.to_csv(out_fn_center_df, index = False)
+
+
+def compare_bkgd_cntl_outputs():
+    output_stem     =   'm60_test_main_version'
+    centers_df_old = pd.read_csv('{}.bkgd_cntl_nn2.centers_df.csv'.format(output_stem))
+    centers_df_new  = pd.read_csv('{}.bkgd_cntl_nn3.centers_df.csv'.format(output_stem))
+    assert(centers_df_old.round(6).equals(centers_df_new.round(6))) #rounding to dodge floating point error
+
+
+test_bkgd_cntl_nn2_setup()
+test_bkgd_cntl_nn2()
+test_bkgd_cntl_nn3()
+
+#now compare the output - AssertionError if they don't match
+compare_bkgd_cntl_outputs()
+
+
+


### PR DESCRIPTION
See issue #77

The modified version of bkgd_cntl_nn3 greatly reduces memory usage and increases speed compared to bkgd_cntl_nn2.  Memory usage is reduced by summing regex hits (and calculating weighted sums) on the fly, rather than after all hits have been found.  Speed is increased by pre-compiling regex.

bkgd_cntl_nn3 calls the new _multi_regex_weighted function rather than _multi_regex.  This takes a compiled regex, target seqs, and optionally weights, and returns a tuple giving sum of hits and weighted sum (the latter value is None if no weights were supplied).

Tests are provided to confirm that bkgd_cntl_nn2 and bkgd_cntl_nn3 produce the same results (in test_bkgd_cntl_nn3_vs_bkgd_cntl_nn2.py).

