### PR TITLE
Added support on pandas version 1.5.0+ due to the issue caused by **pandas.DataFrame.iteritems**.

### DIFF
--- a/tcrdist/gene_pairing_plot.py
+++ b/tcrdist/gene_pairing_plot.py
@@ -312,10 +312,10 @@ def plot_pairings(cell_df, cols, count_col=None, use_color_gradients=True, other
         a1pixels = {}
         yleft = yspacer + top_margin
         """Nested loops over the alleles (a0, a1) in the pair of columns, r0, r1"""
-        for a0, a0count in counts[r0].iteritems():
+        for a0, a0count in counts[r0].items():
             y0_right = yspacer + top_margin
             a0color = r0colors[a0]
-            for a1, a1count in counts[r1].iteritems():
+            for a1, a1count in counts[r1].items():
                 a1color = r1colors[a1]
                 vj = (a0, a1)
                 a1color = r1colors[a1]
@@ -407,7 +407,7 @@ def plot_pairings(cell_df, cols, count_col=None, use_color_gradients=True, other
 
             x = x0 + jj*(flat_band + middle_band)
             ystart = yspacer + top_margin
-            for a, acount in counts[r].iteritems():
+            for a, acount in counts[r].items():
                 if acount*ypixel_scale < min_height_for_labels:
                     #print(acount * ypixel_scale)
                     break

--- a/tcrdist/rep_diff.py
+++ b/tcrdist/rep_diff.py
@@ -199,7 +199,7 @@ def member_summ(res_df, clone_df, key_col = 'neighbors_i', count_col='count', ad
         gby = m.groupby(col)[count_col].agg(np.sum)
         gby = 100 * gby / gby.sum()
         gby = gby.sort_values(ascending=False)
-        out = ', '.join(['%s (%2.1f%%)' % (idx, v) for idx,v in gby.iteritems()][:N])
+        out = ', '.join(['%s (%2.1f%%)' % (idx, v) for idx,v in gby.items()][:N])
         return out
     
     split = []

--- a/tcrdist/summarize.py
+++ b/tcrdist/summarize.py
@@ -227,7 +227,7 @@ def _occurs_N_str(m, N):
         gby = m.value_counts()
     gby = 100 * gby / gby.sum()
     gby = gby.sort_values(ascending=False)
-    out = ', '.join(['%s (%2.1f%%)' % (idx, v) for idx,v in gby.iteritems()][:N])
+    out = ', '.join(['%s (%2.1f%%)' % (idx, v) for idx,v in gby.items()][:N])
     return out
 
 
@@ -242,7 +242,7 @@ def _top_N_str(m, col, count_col, N):
     gby = m.groupby(col)[count_col].agg(np.sum)
     gby = 100 * gby / gby.sum()
     gby = gby.sort_values(ascending=False)
-    out = ', '.join(['%s (%2.1f%%)' % (idx, v) for idx,v in gby.iteritems()][:N])
+    out = ', '.join(['%s (%2.1f%%)' % (idx, v) for idx,v in gby.items()][:N])
     return out
 
 
@@ -318,7 +318,7 @@ def member_summ(res_df, clone_df, key_col = 'neighbors_i', count_col='count', ad
         gby = m.groupby(col)[count_col].agg(np.sum)
         gby = 100 * gby / gby.sum()
         gby = gby.sort_values(ascending=False)
-        out = ', '.join(['%s (%2.1f%%)' % (idx, v) for idx,v in gby.iteritems()][:N])
+        out = ', '.join(['%s (%2.1f%%)' % (idx, v) for idx,v in gby.items()][:N])
         return out
     
     split = []


### PR DESCRIPTION
Dear @kmayerb 
Since Pandas version 1.5.0, pandas announced to romove the function **pandas.DataFrame.iteritems** in the future version of pandas, especially pandas v2.2.1 in 2024.

See [https://pandas.pydata.org/pandas-docs/version/1.5/reference/api/pandas.DataFrame.iteritems.html](url)

I've discovered the issue caused by function **pandas.DataFrame.iteritems** in tcrdist v0.2.2 in gene_pairing_plot.py/rep_diff.py/summarize.py when installing Pandas version later than 1.5.0. However, the automatic installing of tcrdist3 in pip will install the lastest version of pandas and some of the fresh pythoners will not discover the problem caused by pandas.

Thus makes the change. (I've tested that all changes can work correctly.)
Best wishes
Oumae Kaede in KI
