### PR TITLE
docs: fix typo 'intall' → 'install' in macOS installation instructions

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,7 +33,7 @@ If you are having trouble installing on OSX, here are some additional steps that
 users have done to install tcrdist3 on OS X from scratch:
 
 1. Install Homebrew: https://brew.sh (copy the command from the webpage into Terminal app)
-2. In Terminal intall the following (or parasail may not build): 
+2. In Terminal install the following (or parasail may not build): 
 
 .. code-block:: none
 


### PR DESCRIPTION
Fixes a minor typo in the macOS installation section (“intall” → “install”). The word "intall" was corrected to "install to improve clarity. This is a documentation change only and has no effect on the code.